### PR TITLE
Fix/button component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "phoenixcoders",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.1.0",
         "@tanstack/react-query": "^5.53.3",
         "@tanstack/react-query-devtools": "^5.53.3",
         "axios": "^1.7.7",
@@ -1592,6 +1593,39 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
@@ -1969,14 +2003,14 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
       "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3220,7 +3254,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
     "@tanstack/react-query": "^5.53.3",
     "@tanstack/react-query-devtools": "^5.53.3",
     "axios": "^1.7.7",

--- a/src/components/Button/button.spec.tsx
+++ b/src/components/Button/button.spec.tsx
@@ -1,48 +1,51 @@
 import { render, screen } from "@testing-library/react";
 
-import "@testing-library/jest-dom";
+import { Button } from "./";
 
-import { Button } from "./index";
-
-jest.mock("next/router", () => ({
-  useRouter: jest.fn()
-}));
-describe("Button component", () => {
-  it("renders the button with the correct text", () => {
-    render(<Button href="/cadastro" />);
-    const button = screen.getByText("Faça parte");
-
-    expect(button).toBeInTheDocument();
+describe("<Button />", () => {
+  it("should render a button element by default", () => {
+    render(<Button>Faça parte</Button>);
+    const buttonElement = screen.getByRole("button", { name: "Faça parte" });
+    expect(buttonElement).toBeInTheDocument();
   });
 
-  it("applies the primary variant class by default", () => {
-    render(<Button href="/cadastro" />);
-    const button = screen.getByText("Faça parte");
-
-    expect(button).toHaveClass("bg-blue-1 text-blue-3");
+  it("should render the Slot component if 'asChild' is true", () => {
+    render(
+      <Button asChild>
+        <a href="/">Faça parte</a>
+      </Button>
+    );
+    const linkElement = screen.getByRole("link", { name: "Faça parte" });
+    expect(linkElement).toBeInTheDocument();
   });
 
-  it("applies the secondary variant class when specified", () => {
-    render(<Button href="/cadastro" variant="secondary" />);
-    const button = screen.getByText("Faça parte");
-
-    expect(button).toHaveClass("text-neutral-1 border border-neutral-1");
+  it("should apply primary variant classes by default", () => {
+    render(<Button>Faça parte</Button>);
+    const buttonElement = screen.getByRole("button", { name: "Faça parte" });
+    expect(buttonElement).toHaveClass("bg-blue-1 text-blue-3");
   });
-  it("applies the size variant class by default", () => {
-    render(<Button href="/cadastro" />);
-    const button = screen.getByText("Faça parte");
 
-    expect(button).toHaveClass("w-60");
+  it("should apply secondary variant classes", () => {
+    render(<Button variant="secondary">Faça parte</Button>);
+    const buttonElement = screen.getByRole("button", { name: "Faça parte" });
+    expect(buttonElement).toHaveClass("text-neutral-1 border-neutral-1");
   });
-  it("applies the size variant class by full", () => {
-    render(<Button href="/cadastro" size="full" />);
-    const button = screen.getByText("Faça parte");
 
-    expect(button).toHaveClass("w-96");
+  it("should apply full size class when size is 'full'", () => {
+    render(<Button size="full">Faça parte</Button>);
+    const buttonElement = screen.getByRole("button", { name: "Faça parte" });
+    expect(buttonElement).toHaveClass("w-full");
   });
-  it("navigates to the correct URL on click", () => {
-    render(<Button href="/cadastro" />);
-    const button = screen.getByRole("link", { name: /faça parte/i });
-    expect(button).toHaveAttribute("href", "/cadastro");
+
+  it("should forward the ref to the button element", () => {
+    const ref = { current: null };
+    render(<Button ref={ref}>Faça parte</Button>);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it("should accept and apply custom className", () => {
+    render(<Button className="custom-class">Faça parte</Button>);
+    const buttonElement = screen.getByRole("button", { name: "Faça parte" });
+    expect(buttonElement).toHaveClass("custom-class");
   });
 });

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,9 +1,12 @@
-import Link, { LinkProps } from "next/link";
+import { ComponentProps, forwardRef } from "react";
 
+import { Slot } from "@radix-ui/react-slot";
 import { tv, VariantProps } from "tailwind-variants";
 
+import { cn } from "@/lib/utils";
+
 const buttonVariants = tv({
-  base: "h-14 flex items-center justify-center rounded-lg gap-2 text-ParagraphLg font-semibold",
+  base: "flex items-center justify-center rounded-lg gap-2 font-semibold text-lg transition-colors ",
   variants: {
     variant: {
       primary:
@@ -12,8 +15,8 @@ const buttonVariants = tv({
         "text-neutral-1 border border-neutral-1 hover:border-neutral-hover active:border-blue-1"
     },
     size: {
-      default: "w-60",
-      full: "w-96"
+      default: "w-60 h-[60px]",
+      full: "w-full h-[60px]"
     }
   },
 
@@ -22,11 +25,21 @@ const buttonVariants = tv({
     size: "default"
   }
 });
-interface ButtonProps extends LinkProps, VariantProps<typeof buttonVariants> {}
-export const Button = ({ size, variant, ...props }: ButtonProps) => {
-  return (
-    <Link {...props} className={buttonVariants({ variant, size })}>
-      Faça parte
-    </Link>
-  );
-};
+type ButtonProps = ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...rest }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...rest}
+      />
+    );
+  }
+);
+Button.displayName = "Button";


### PR DESCRIPTION
### Descrição
Este pull request refatora o componente `<Button />` para melhorar a flexibilidade e otimizar sua usabilidade.
As principais mudanças incluem:
- [x] **Adição do forwardRef**: Permite passar referências diretamente ao botão, facilitando a integração com bibliotecas de animação e outras funcionalidades que dependem de refs.
- [x] **Uso do Slot da Radix UI**: Agora é possível passar componentes customizados como filhos do botão utilizando a prop `asChild`, mantendo a semântica e estrutura desejada.
- [x] **Melhoria no estilo base**: Adicionado suporte para a transição de cores e padronização de altura do botão (60px) para garantir consistência visual.
- [x] Remoção do `Link` do Next.js: O componente foi ajustado para funcionar como um `button` nativo, mas ainda pode ser adaptado para outras tags usando a prop `asChild`.
- [x] Suporte a Classes Dinâmicas: Agora o componente utiliza a função `cn` para combinar classes CSS de forma dinâmica.

### Print do botão atualizado
![image](https://github.com/user-attachments/assets/07648dff-a583-41b7-ba4f-fee66b0a995d)
